### PR TITLE
Use then to be backwards compatible

### DIFF
--- a/packages/airgram/src/components/TdClient.ts
+++ b/packages/airgram/src/components/TdClient.ts
@@ -121,7 +121,7 @@ export class TdClient {
         .then(() => this.receive())
         .then((response) => this.addToStack(response))
         .catch(this.handleError)
-        .finally(() => setImmediate(() => this.loop()))
+        .then(() => setImmediate(() => this.loop()))
     }
   }
 


### PR DESCRIPTION
Altough finally is more semantically correct. then is also appliable here and leads to be backwards compatible to node 8